### PR TITLE
feat: Use ForwardedHeaderOptions / ForwardedHeaderOptions

### DIFF
--- a/sample/NetEnhancements.Web/Controllers/FooController.cs
+++ b/sample/NetEnhancements.Web/Controllers/FooController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using NetEnhancements.AspNet;
 
 namespace NetEnhancements.Web.Controllers
 {
@@ -6,7 +7,9 @@ namespace NetEnhancements.Web.Controllers
     {
         public IActionResult Index()
         {
-            return Content("/Foo");
+            var clientIp = Request.HttpContext.GetRequestIPAddress();
+
+            return Content(clientIp);
         }
     }
 }

--- a/sample/NetEnhancements.Web/Program.cs
+++ b/sample/NetEnhancements.Web/Program.cs
@@ -29,6 +29,8 @@ builder.Services.AddAuthorization(o =>
     });
 });
 
+builder.Services.ConfigureCloudflareForwarding();
+
 AreaPolicy[] areaPolicies = 
 [
     // Identity area: uses its own policies, leave as-is.
@@ -64,6 +66,8 @@ mvcBuilder.AddRazorPagesOptions(options =>
 mvcBuilder.AddRouteDebugger();
 
 var app = builder.Build();
+
+app.UseForwardedHeaders();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/NetEnhancements.AspNet/HttpContextExtensions.cs
+++ b/src/NetEnhancements.AspNet/HttpContextExtensions.cs
@@ -5,17 +5,14 @@ namespace NetEnhancements.AspNet
 {
     public static class HttpContextExtensions
     {
+        /// <summary>
+        /// Returns the IPv4(-mapped from IPv6 when necessary) address of the client making the request. If the address is not available, returns "(Unknown)".
+        /// </summary>
         [DebuggerStepThrough]
         public static string GetRequestIPAddress(this HttpContext context)
         {
-            if (context.Request.Headers.TryGetValue(SharedConstants.XForwardedFor, out var forwardedHeader))
-            {
-                return forwardedHeader.ToString().Split(',').First();
-            }
-
             return context.Connection.RemoteIpAddress?.MapToIPv4().ToString()
                 ?? SharedConstants.UnknownIpAddress;
-
         }
     }
 }

--- a/src/NetEnhancements.AspNet/ServiceProviderExtensions_Cloudflare.cs
+++ b/src/NetEnhancements.AspNet/ServiceProviderExtensions_Cloudflare.cs
@@ -1,0 +1,66 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using IPNetwork = System.Net.IPNetwork;
+
+namespace NetEnhancements.AspNet
+{
+    /// <summary>
+    /// Extension methods container for Cloudflare proxying.
+    /// </summary>
+    /// <url>https://www.cloudflare.com/ips/</url>
+    public static class ServiceProviderExtensions
+    {
+        private const ForwardedHeaders DefaultAllowedHeaders = ForwardedHeaders.XForwardedFor;
+
+        private static readonly IPNetwork[] TrustedNetworks =
+        {
+            // IPv4 - https://www.cloudflare.com/ips-v4/#
+            new(IPAddress.Parse("173.245.48.0"), 20),
+            new(IPAddress.Parse("103.21.244.0"), 22),
+            new(IPAddress.Parse("103.22.200.0"), 22),
+            new(IPAddress.Parse("103.31.4.0"), 22),
+            new(IPAddress.Parse("141.101.64.0"), 18),
+            new(IPAddress.Parse("108.162.192.0"), 18),
+            new(IPAddress.Parse("190.93.240.0"), 20),
+            new(IPAddress.Parse("188.114.96.0"), 20),
+            new(IPAddress.Parse("197.234.240.0"), 22),
+            new(IPAddress.Parse("198.41.128.0"), 17),
+            new(IPAddress.Parse("162.158.0.0"), 15),
+            new(IPAddress.Parse("104.16.0.0"), 13),
+            new(IPAddress.Parse("104.24.0.0"), 14),
+            new(IPAddress.Parse("172.64.0.0"), 13),
+            new(IPAddress.Parse("131.0.72.0"), 22),
+
+            // IPv6 - https://www.cloudflare.com/ips-v6/#
+            new(IPAddress.Parse("2400:cb00::"), 32),
+            new(IPAddress.Parse("2606:4700::"), 32),
+            new(IPAddress.Parse("2803:f800::"), 32),
+            new(IPAddress.Parse("2405:b500::"), 32),
+            new(IPAddress.Parse("2405:8100::"), 32),
+            new(IPAddress.Parse("2a06:98c0::"), 29),
+            new(IPAddress.Parse("2c0f:f248::"), 32),
+        };
+
+        /// <summary>
+        /// Configure Cloudflare proxy IPs as safe to trust X-Forwarded-For headers. This is required to get the correct client IP address when using Cloudflare as a reverse proxy.
+        ///
+        /// After calling this method to configure, call <see cref="ForwardedHeadersExtensions.UseForwardedHeaders(Microsoft.AspNetCore.Builder.IApplicationBuilder)"/> (<c>app.UseForwardedHeaders()</c>) before any other middleware.
+        /// </summary>
+        public static IServiceCollection ConfigureCloudflareForwarding(this IServiceCollection services, ForwardedHeaders? forwardedHeaders = DefaultAllowedHeaders)
+        {
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = forwardedHeaders ?? DefaultAllowedHeaders;
+
+                foreach (var network in TrustedNetworks)
+                {
+                    options.KnownIPNetworks.Add(network);
+                }
+            });
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
MS Docs: [Configure ASP.NET Core to work with proxy servers and load balancers](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-10.0)

With Cloudflare IPs from https://www.cloudflare.com/ips/.

What this fixes: we unconditionally trusted X-Forwarded-For headers; now we offload that to a built-in, configurable middleware - and we configure it.